### PR TITLE
fix: resolve path normalization issue in DocReader cache

### DIFF
--- a/kaiwu/knowledge/doc_reader.py
+++ b/kaiwu/knowledge/doc_reader.py
@@ -113,7 +113,7 @@ class DocReader:
         return result
 
     def _read_file(self, path: Path) -> list[str]:
-        key = str(path)
+        key = str(path.resolve())
         if key in self._cache:
             return self._cache[key]
 

--- a/kaiwu/tests/test_p1_features.py
+++ b/kaiwu/tests/test_p1_features.py
@@ -349,13 +349,14 @@ Connection pooling is configured in src/db/pool.py.
 
     def test_cache(self):
         from kaiwu.knowledge.doc_reader import DocReader
+        from pathlib import Path
         with tempfile.TemporaryDirectory() as d:
             with open(os.path.join(d, "doc.md"), "w", encoding="utf-8") as f:
                 f.write("This is a test document with enough content to be a paragraph.\n")
             reader = DocReader(d)
             reader.find_relevant("test")
-            # Second call should use cache
-            assert str(os.path.join(d, "doc.md")) in reader._cache
+            # Second call should use cache (use resolved path for comparison)
+            assert str(Path(d, "doc.md").resolve()) in reader._cache
 
 
 # ── PatternMd.count_similar_failures ───────────────────────


### PR DESCRIPTION
## Summary
Fix cross-platform path normalization bug in DocReader that caused test failures on Windows and macOS.

## Problem
- **Windows**: Short path format (`C:\Users\RUNNER~1\...`) vs full path (`C:\Users\runneradmin\...`)
- **macOS**: Symlink `/var` vs canonical `/private/var`

The cache used one path format as key, but lookups used another, causing cache misses and test failures.

## Solution
- Use `path.resolve()` for cache keys to ensure consistent absolute paths across platforms
- Update test to use resolved paths for cache key comparison

## Test Results
✅ Local test passes on macOS
✅ Should fix Windows CI failure in [run #25179048541](https://github.com/val1813/kwcode/actions/runs/25179048541)

Fixes: `kaiwu/tests/test_p1_features.py::TestDocReader::test_cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)