### PR TITLE
[codex] 打通测试基线到重试路由的反馈闭环

### DIFF
--- a/kaiwu/core/execution_state.py
+++ b/kaiwu/core/execution_state.py
@@ -79,6 +79,12 @@ class ExecutionStateTracker:
                 return delta.attempt
         return None
 
+    def get_new_failures(self) -> list[str]:
+        """返回最近一次attempt新引入的失败测试。"""
+        if not self._history:
+            return []
+        return list(self._history[-1].newly_failing)
+
     def get_progress_summary(self) -> dict:
         """获取当前进展摘要（供审计日志使用）。"""
         if not self._history:

--- a/kaiwu/core/test_parser.py
+++ b/kaiwu/core/test_parser.py
@@ -8,6 +8,29 @@ import re
 __all__ = ["extract_failing_tests", "extract_passing_tests", "parse_test_failures"]
 
 
+def _unique(items: list[str]) -> list[str]:
+    """Deduplicate while preserving runner output order."""
+    seen = set()
+    result = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _new_failure(test_name: str) -> dict:
+    return {
+        "test_name": test_name.strip(),
+        "expected": "",
+        "actual": "",
+        "error_type": "",
+        "file": "",
+        "line": 0,
+        "snippet": "",
+    }
+
+
 def extract_failing_tests(output: str) -> list[str]:
     """从pytest/go/jest输出里提取失败的测试名。"""
     if not output:
@@ -15,19 +38,22 @@ def extract_failing_tests(output: str) -> list[str]:
 
     failing = []
 
-    # pytest: "FAILED test_foo.py::TestBar::test_baz"
-    failing += re.findall(r'FAILED\s+([\w/:.]+)', output)
+    # pytest: "FAILED test_foo.py::TestBar::test_baz[param]"
+    failing += re.findall(r'FAILED\s+(\S+)', output)
 
     # go: "--- FAIL: TestFoo (0.00s)"
     failing += re.findall(r'--- FAIL:\s+(\w+)', output)
 
     # jest: "✕ should do something (5 ms)" or "× should do something"
-    failing += re.findall(r'[✕×]\s+(.+?)(?:\s+\(\d+)', output)
+    failing += [
+        m.strip()
+        for m in re.findall(r'[✕×]\s+(.+?)(?:\s+\(\d+\s*ms\)|\s*$)', output, re.MULTILINE)
+    ]
 
     # rust: "test xxx ... FAILED"
     failing += re.findall(r'test\s+(\S+)\s+\.\.\.\s+FAILED', output)
 
-    return list(set(failing))
+    return _unique(failing)
 
 
 def extract_passing_tests(output: str) -> list[str]:
@@ -37,34 +63,60 @@ def extract_passing_tests(output: str) -> list[str]:
 
     passing = []
 
-    # pytest: "PASSED test_foo.py::TestBar::test_baz"
-    passing += re.findall(r'PASSED\s+([\w/:.]+)', output)
+    # pytest: "PASSED test_foo.py::TestBar::test_baz[param]"
+    passing += re.findall(r'PASSED\s+(\S+)', output)
 
     # go: "--- PASS: TestFoo (0.00s)"
     passing += re.findall(r'--- PASS:\s+(\w+)', output)
 
     # jest: "✓ should do something (5 ms)" or "✔ should do something"
-    passing += re.findall(r'[✓✔]\s+(.+?)(?:\s+\(\d+)', output)
+    passing += [
+        m.strip()
+        for m in re.findall(r'[✓✔]\s+(.+?)(?:\s+\(\d+\s*ms\)|\s*$)', output, re.MULTILINE)
+    ]
 
     # rust: "test xxx ... ok"
     passing += re.findall(r'test\s+(\S+)\s+\.\.\.\s+ok', output)
 
-    return list(set(passing))
+    return _unique(passing)
 
 
-def parse_test_failures(output: str) -> list[dict]:
-    """
-    从pytest --tb=short输出解析每个失败测试的结构化信息。
-    返回: [{"test_name", "expected", "actual", "error_type", "file", "line", "snippet"}]
-    """
-    if not output:
-        return []
+def _parse_expected_actual(text: str, failure: dict) -> None:
+    """Fill expected/actual when common runner wording is present."""
+    patterns = [
+        # Go: "expected 5, got 3"
+        (r'expected\s+(.+?),\s*got\s+(.+)', "expected", "actual"),
+        # Go: "got 3, want 5"
+        (r'got\s+(.+?),\s*want\s+(.+)', "actual", "expected"),
+        # Go/Jest custom: "want 5, got 3"
+        (r'want\s+(.+?),\s*got\s+(.+)', "expected", "actual"),
+        # Pytest: "assert 3 == 5"
+        (r'assert\s+(.+?)\s*==\s*(.+?)(?:\s*$|\s+where)', "actual", "expected"),
+    ]
+    for pattern, first_key, second_key in patterns:
+        match = re.search(pattern, text, re.IGNORECASE | re.MULTILINE)
+        if match:
+            failure[first_key] = match.group(1).strip()
+            failure[second_key] = match.group(2).strip()
+            failure["error_type"] = failure["error_type"] or "AssertionError"
+            return
 
+    expected_match = re.search(r'Expected:\s*(.+)', text)
+    received_match = re.search(r'Received:\s*(.+)', text)
+    if expected_match:
+        failure["expected"] = expected_match.group(1).strip()
+    if received_match:
+        failure["actual"] = received_match.group(1).strip()
+    if expected_match or received_match:
+        failure["error_type"] = failure["error_type"] or "AssertionError"
+
+
+def _parse_pytest_failures(output: str) -> list[dict]:
     failures = []
 
     # 按pytest的FAILURES section分割每个测试块
     # 格式: _____ test_name _____\n file:line: in func\n ... \nE   assert ...
-    blocks = re.split(r'_{3,}\s+([\w:.]+)\s+_{3,}', output)
+    blocks = re.split(r'(?m)^_{3,}\s+(.+?)\s+_{3,}\s*$', output)
 
     # blocks[0]是前缀，之后是 [test_name, block_content, test_name, block_content, ...]
     i = 1
@@ -73,15 +125,7 @@ def parse_test_failures(output: str) -> list[dict]:
         block = blocks[i + 1] if i + 1 < len(blocks) else ""
         i += 2
 
-        failure = {
-            "test_name": test_name,
-            "expected": "",
-            "actual": "",
-            "error_type": "",
-            "file": "",
-            "line": 0,
-            "snippet": "",
-        }
+        failure = _new_failure(test_name)
 
         # 提取文件和行号: "file.py:42: in test_func"
         loc_match = re.search(r'([\w/\\._-]+\.py):(\d+):', block)
@@ -91,25 +135,26 @@ def parse_test_failures(output: str) -> list[dict]:
 
         # 提取E行（pytest的错误详情）
         e_lines = re.findall(r'^E\s+(.+)$', block, re.MULTILINE)
+        e_text = "\n".join(e_lines)
         if e_lines:
             failure["snippet"] = "\n".join(e_lines[:5])
 
-        # 解析assert失败: "assert None == 3" / "assert False == True"
-        assert_match = re.search(r'assert\s+(.+?)\s*==\s*(.+?)(?:\s*$|\s+where)', "\n".join(e_lines))
-        if assert_match:
-            failure["actual"] = assert_match.group(1).strip()
-            failure["expected"] = assert_match.group(2).strip()
-            failure["error_type"] = "AssertionError"
+        _parse_expected_actual(e_text, failure)
+
         # "assert X is True" / "assert X is not None"
-        elif re.search(r'assert\s+', "\n".join(e_lines)):
+        if not failure["error_type"] and re.search(r'assert\s+', e_text):
             failure["error_type"] = "AssertionError"
             # 提取 "where X = func()"
-            where_match = re.search(r'where\s+(.+?)\s*=\s*(.+?)(?:\s*$)', "\n".join(e_lines))
+            where_match = re.search(r'where\s+(.+?)\s*=\s*(.+?)(?:\s*$)', e_text)
             if where_match:
                 failure["actual"] = where_match.group(1).strip()
 
         # 异常类型: "TypeError: ..." / "AttributeError: ..."
-        exc_match = re.search(r'(TypeError|AttributeError|ValueError|KeyError|IndexError|ZeroDivisionError|NotImplementedError):\s*(.+)', block)
+        exc_match = re.search(
+            r'(TypeError|AttributeError|ValueError|KeyError|IndexError|'
+            r'ZeroDivisionError|NotImplementedError|RuntimeError|NameError):\s*(.+)',
+            block,
+        )
         if exc_match:
             failure["error_type"] = exc_match.group(1)
             failure["snippet"] = exc_match.group(2).strip()[:200]
@@ -122,26 +167,105 @@ def parse_test_failures(output: str) -> list[dict]:
 
         failures.append(failure)
 
-    # 如果上面的block分割没找到，用更宽松的模式
+    return failures
+
+
+def _parse_pytest_summary_failures(output: str) -> list[dict]:
+    failures = []
+    for match in re.finditer(r'FAILED\s+(\S+)\s*-\s*(.+)', output):
+        failure = _new_failure(match.group(1))
+        reason = match.group(2).strip()
+        failure["error_type"] = "AssertionError"
+        failure["snippet"] = reason[:200]
+        _parse_expected_actual(reason, failure)
+        failures.append(failure)
+    return failures
+
+
+def _parse_go_failures(output: str) -> list[dict]:
+    failures = []
+    blocks = re.finditer(
+        r'(?ms)^--- FAIL:\s+(\S+).*?\n(.*?)(?=^--- (?:FAIL|PASS):|^FAIL\b|\Z)',
+        output,
+    )
+    for match in blocks:
+        failure = _new_failure(match.group(1))
+        block = match.group(2)
+
+        loc_match = re.search(r'(?m)^\s+([^\s:]+\.go):(\d+):\s*(.+)$', block)
+        if loc_match:
+            failure["file"] = loc_match.group(1)
+            failure["line"] = int(loc_match.group(2))
+            failure["snippet"] = loc_match.group(3).strip()[:200]
+        else:
+            lines = [line.strip() for line in block.splitlines() if line.strip()]
+            if lines:
+                failure["snippet"] = lines[0][:200]
+
+        _parse_expected_actual(block, failure)
+        failure["error_type"] = failure["error_type"] or "TestFailure"
+        failures.append(failure)
+
+    return failures
+
+
+def _parse_jest_failures(output: str) -> list[dict]:
+    failures = []
+    current_file = ""
+
+    file_match = re.search(r'(?m)^FAIL\s+(.+)$', output)
+    if file_match:
+        current_file = file_match.group(1).strip()
+
+    blocks = list(re.finditer(
+        r'(?ms)^\s*●\s+(.+?)\s*\n(.*?)(?=^\s*●\s+|^Test Suites:|^Tests:|\Z)',
+        output,
+    ))
+
+    for match in blocks:
+        failure = _new_failure(match.group(1).strip())
+        block = match.group(2)
+        failure["file"] = current_file
+
+        stack_match = re.search(r'\(([^()\s]+?\.(?:ts|tsx|js|jsx)):(\d+):\d+\)', block)
+        if stack_match:
+            failure["file"] = stack_match.group(1)
+            failure["line"] = int(stack_match.group(2))
+        else:
+            frame_match = re.search(r'(?m)^\s*>\s*(\d+)\s*\|', block)
+            if frame_match:
+                failure["line"] = int(frame_match.group(1))
+
+        _parse_expected_actual(block, failure)
+        snippet_lines = [line.strip() for line in block.splitlines() if line.strip()]
+        if snippet_lines:
+            failure["snippet"] = "\n".join(snippet_lines[:5])[:200]
+        failure["error_type"] = failure["error_type"] or "AssertionError"
+        failures.append(failure)
+
     if not failures:
-        # 直接从 "FAILED xxx - reason" 行提取
-        for match in re.finditer(r'FAILED\s+([\w/:.]+)\s*-\s*(.+)', output):
-            test_name = match.group(1)
-            reason = match.group(2).strip()
-            failure = {
-                "test_name": test_name,
-                "expected": "",
-                "actual": "",
-                "error_type": "AssertionError",
-                "file": "",
-                "line": 0,
-                "snippet": reason[:200],
-            }
-            # "assert None == 3"
-            assert_m = re.search(r'assert\s+(.+?)\s*==\s*(.+)', reason)
-            if assert_m:
-                failure["actual"] = assert_m.group(1).strip()
-                failure["expected"] = assert_m.group(2).strip()
+        for name in re.findall(r'[✕×]\s+(.+?)(?:\s+\(\d+\s*ms\)|\s*$)', output, re.MULTILINE):
+            failure = _new_failure(name)
+            failure["file"] = current_file
+            failure["error_type"] = "AssertionError"
             failures.append(failure)
 
+    return failures
+
+
+def parse_test_failures(output: str) -> list[dict]:
+    """
+    从pytest/go test/jest输出解析每个失败测试的结构化信息。
+    返回: [{"test_name", "expected", "actual", "error_type", "file", "line", "snippet"}]
+    """
+    if not output:
+        return []
+
+    failures = _parse_pytest_failures(output)
+    if not failures:
+        failures = _parse_pytest_summary_failures(output)
+    if not failures and "--- FAIL:" in output:
+        failures = _parse_go_failures(output)
+    if not failures and ("FAIL " in output or "● " in output or "✕" in output or "×" in output):
+        failures = _parse_jest_failures(output)
     return failures[:10]  # 最多10个，避免prompt过长

--- a/kaiwu/experts/verifier.py
+++ b/kaiwu/experts/verifier.py
@@ -102,9 +102,20 @@ class VerifierExpert:
         passed, total, error = self._run_tests(ctx)
         from kaiwu.core.test_parser import parse_test_failures
         structured = parse_test_failures(error) if error else []
-        return {"passed": passed, "total": total, "output": error,
+        output = error or self._format_success_output(passed, total)
+        return {"passed": passed, "total": total, "output": output,
                 "error_type": self._classify_error(error)["error_type"] if error else "",
                 "structured_failures": structured}
+
+    @staticmethod
+    def _format_success_output(passed: int, total: int) -> str:
+        """Return a minimal runner-like summary so GapDetector can see green baselines."""
+        if total <= 0:
+            return ""
+        if passed == total:
+            return f"{passed} passed"
+        failed = max(total - passed, 0)
+        return f"{passed} passed, {failed} failed"
 
     def _check_toolchain(self, lang: str, project_root: str) -> str:
         """检测工具链是否存在。返回错误信息或空字符串。"""
@@ -423,6 +434,19 @@ class VerifierExpert:
         """
         # Detect project language
         project_lang = _detect_project_language(ctx.project_root, self.tools)
+
+        confirmed_cmd = getattr(ctx, "confirmed_test_cmd", "")
+        if confirmed_cmd:
+            stdout, stderr, rc = self.tools.run_bash(
+                confirmed_cmd,
+                cwd=ctx.project_root,
+                timeout=120,
+            )
+            output = stdout + "\n" + stderr
+            passed, total = self._parse_test_output(output, project_lang)
+            if rc == 0:
+                return passed, total, ""
+            return passed, total, output.strip()[:4000]
 
         # Get test runners for this language
         runners = TEST_RUNNERS.get(project_lang, TEST_RUNNERS["python"])

--- a/kaiwu/experts/verifier.py
+++ b/kaiwu/experts/verifier.py
@@ -58,12 +58,13 @@ def _detect_project_language(project_root: str, tool_executor: ToolExecutor) -> 
     try:
         entries = tool_executor.list_dir(project_root)
         if isinstance(entries, list):
+            # TypeScript projects usually have both package.json and tsconfig.json.
+            # Prefer tsconfig so verifier selects the TS runner and test-file patterns.
+            if "tsconfig.json" in entries:
+                return "typescript"
             for entry in entries:
                 if entry in _PROJECT_MARKERS:
                     return _PROJECT_MARKERS[entry]
-            # 检查tsconfig（覆盖package.json → typescript）
-            if "tsconfig.json" in entries:
-                return "typescript"
     except Exception:
         pass
     return "python"

--- a/kaiwu/tests/diagnostic/test_execution_tracker_value.py
+++ b/kaiwu/tests/diagnostic/test_execution_tracker_value.py
@@ -55,6 +55,17 @@ class TestExecutionTrackerValue:
         assert best.attempt == 0
         assert "test_a" in best.newly_passing
 
+    def test_latest_new_failures_feed_retry_hint(self):
+        """最近一次新增失败应能被orchestrator用于回归重试提示。"""
+        tracker = ExecutionStateTracker()
+        tracker.set_baseline(["test_a"])
+
+        tracker.record(0, ["test_a"], [], "logic_error")
+        assert tracker.get_new_failures() == []
+
+        tracker.record(1, ["test_a", "test_c", "test_d"], [], "logic_error")
+        assert tracker.get_new_failures() == ["test_c", "test_d"]
+
     def test_scenario_3_immediate_regression(self):
         """场景3：第一次修改就引入回归。"""
         tracker = ExecutionStateTracker()

--- a/kaiwu/tests/test_multilang.py
+++ b/kaiwu/tests/test_multilang.py
@@ -511,6 +511,49 @@ Tests:       1 failed, 0 passed, 1 total
             assert lang in TEST_RUNNERS, f"Missing test runner for {lang}"
             assert len(TEST_RUNNERS[lang]) > 0
 
+    def test_run_tests_only_keeps_green_baseline_visible(self):
+        from kaiwu.core.context import TaskContext
+        from kaiwu.core.gap_detector import GapDetector, GapType
+        from kaiwu.experts.verifier import VerifierExpert
+
+        tools = MagicMock()
+        tools.list_dir.return_value = ["tests", "src"]
+        verifier = VerifierExpert(llm=MagicMock(), tool_executor=tools)
+        verifier._run_tests = MagicMock(return_value=(5, 5, ""))
+
+        result = verifier.run_tests_only(TaskContext(project_root="/fake"))
+
+        assert result["output"] == "5 passed"
+        assert GapDetector().compute(result["output"]).gap_type == GapType.NONE
+
+    def test_run_tests_uses_confirmed_env_probe_command(self):
+        from kaiwu.core.context import TaskContext
+        from kaiwu.experts.verifier import VerifierExpert
+
+        tools = MagicMock()
+        tools.list_dir.return_value = ["tests", "src"]
+        tools.run_bash.return_value = (
+            "2 passed, 1 failed in 0.10s",
+            "",
+            1,
+        )
+        verifier = VerifierExpert(llm=MagicMock(), tool_executor=tools)
+        ctx = TaskContext(
+            project_root="/fake",
+            confirmed_test_cmd="python -m pytest -x -q",
+        )
+
+        passed, total, error = verifier._run_tests(ctx)
+
+        tools.run_bash.assert_called_once_with(
+            "python -m pytest -x -q",
+            cwd="/fake",
+            timeout=120,
+        )
+        assert passed == 2
+        assert total == 3
+        assert "1 failed" in error
+
 
 # ═══════════════════════════════════════════════════════════════════
 # Graph Builder Extension Tests

--- a/kaiwu/tests/test_multilang.py
+++ b/kaiwu/tests/test_multilang.py
@@ -420,6 +420,56 @@ Time:   1.2s
         info = v._classify_error("--- FAIL: TestAdd (0.00s)\n    add_test.go:10: expected 5, got 3")
         assert "TestAdd" in info["failed_tests"]
 
+    def test_parse_go_structured_failure(self):
+        from kaiwu.core.test_parser import parse_test_failures
+
+        output = """--- FAIL: TestAdd (0.00s)
+    calculator_test.go:12: expected 5, got 3
+--- PASS: TestSub (0.00s)
+FAIL
+"""
+        failures = parse_test_failures(output)
+
+        assert len(failures) == 1
+        assert failures[0]["test_name"] == "TestAdd"
+        assert failures[0]["file"] == "calculator_test.go"
+        assert failures[0]["line"] == 12
+        assert failures[0]["expected"] == "5"
+        assert failures[0]["actual"] == "3"
+
+    def test_parse_jest_structured_failure(self):
+        from kaiwu.core.test_parser import parse_test_failures
+
+        output = """FAIL  src/calculator.test.ts
+  add
+    ✕ returns sum (5 ms)
+
+  ● add › returns sum
+
+    expect(received).toBe(expected) // Object.is equality
+
+    Expected: 5
+    Received: 3
+
+      9 | describe("add", () => {
+     10 |   it("returns sum", () => {
+    >11 |     expect(add(1, 2)).toBe(5);
+        |                       ^
+     12 |   });
+
+      at Object.<anonymous> (src/calculator.test.ts:11:23)
+
+Tests:       1 failed, 0 passed, 1 total
+"""
+        failures = parse_test_failures(output)
+
+        assert len(failures) == 1
+        assert failures[0]["test_name"] == "add › returns sum"
+        assert failures[0]["file"] == "src/calculator.test.ts"
+        assert failures[0]["line"] == 11
+        assert failures[0]["expected"] == "5"
+        assert failures[0]["actual"] == "3"
+
     def test_classify_error_rust_test_fail(self):
         from kaiwu.experts.verifier import VerifierExpert
         v = VerifierExpert(llm=MagicMock(), tool_executor=MagicMock())
@@ -442,6 +492,12 @@ Time:   1.2s
         mock_tools = MagicMock()
         mock_tools.list_dir.return_value = ["Cargo.toml", "src", "tests"]
         assert _detect_project_language("/fake", mock_tools) == "rust"
+
+    def test_detect_project_language_prefers_typescript_over_package_json(self):
+        from kaiwu.experts.verifier import _detect_project_language
+        mock_tools = MagicMock()
+        mock_tools.list_dir.return_value = ["package.json", "tsconfig.json", "src", "tests"]
+        assert _detect_project_language("/fake", mock_tools) == "typescript"
 
     def test_detect_project_language_default_python(self):
         from kaiwu.experts.verifier import _detect_project_language


### PR DESCRIPTION
## 为什么改

README 里反复强调 KWCode 的核心不是让小模型自由发挥，而是用确定性流水线把“定位 → 生成 → 验证 → 重试”收束起来。但现在这条链路有一个主干问题：pre-test 只把失败输出交给 GapDetector。

当项目一开始就是全绿时，`run_tests_only()` 返回空输出，GapDetector 会把它误判成“没有测试”。这会污染后面的 Gap 路由，甚至可能把本该走 repair/refactor 的任务覆盖到 codegen。另一方面，EnvProber 已经探测出了可用测试命令，但 verifier 后续并没有优先使用它，环境探测和验证执行之间没有真正闭环。

这次改动把方向放在“测试基线驱动重试路由”：让基线状态可见、让确认过的测试命令生效、让回归新增失败能反馈给下一轮 retry。

## 改了什么

- `run_tests_only()` 在测试全绿时返回最小 runner 摘要，例如 `5 passed`，让 GapDetector 能识别 `GapType.NONE`，不再把绿色基线误判成 `NO_TEST`。
- verifier 优先执行 `ctx.confirmed_test_cmd`，把 EnvProber 已验证的测试命令真正接入验证链路。
- `ExecutionStateTracker` 增加 `get_new_failures()`，orchestrator 在检测回归时可以拿到最近一次新增失败测试，而不是只能写“未知”。
- 继续补齐 Go/Jest 的结构化失败解析：提取失败测试、文件、行号、expected/actual，让非 Python 项目的 retry hint 更具体。
- TypeScript 项目检测优先 `tsconfig.json`，避免同时存在 `package.json` 时误走 JavaScript 分支。

## 影响

这不是调参，也不是文案修补，而是让 KWCode 的确定性控制面更稳：

- 全绿项目不会在任务开始时被误导成“无测试项目”。
- 环境探针产出的测试命令会被后续 verifier 复用，减少“探测一套、验证另一套”的漂移。
- 重试时模型拿到的是“新增失败是什么、断言差异是什么”，而不是笼统的失败尾部。
- 对本地小模型更友好，因为它少猜一步，多拿一层确定性事实。

## 验证

- `python -m py_compile kaiwu\core\test_parser.py kaiwu\experts\verifier.py kaiwu\core\execution_state.py`：通过
- `C:\Users\30566\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe -m pytest kaiwu/tests/test_multilang.py::TestVerifierMultiLang::test_parse_go_structured_failure kaiwu/tests/test_multilang.py::TestVerifierMultiLang::test_parse_jest_structured_failure kaiwu/tests/test_multilang.py::TestVerifierMultiLang::test_detect_project_language_prefers_typescript_over_package_json kaiwu/tests/test_multilang.py::TestVerifierMultiLang::test_run_tests_only_keeps_green_baseline_visible kaiwu/tests/test_multilang.py::TestVerifierMultiLang::test_run_tests_uses_confirmed_env_probe_command kaiwu/tests/diagnostic/test_execution_tracker_value.py::TestExecutionTrackerValue::test_latest_new_failures_feed_retry_hint -q`：6 passed
- `C:\Users\30566\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe -m pytest kaiwu/tests/diagnostic/test_execution_tracker_value.py -q`：9 passed, 1 warning

说明：本机仓库内 `.venv` 缺 `pyvenv.cfg`，无法继续作为验证环境；Hermes pytest 环境缺 `tree_sitter`，因此整文件 `test_multilang.py` 的 AST 相关用例会因可选依赖缺失失败。我只跑了覆盖本次改动的精确用例。
