### PR TITLE
feat: 添加内存硬件感知的模型能力检测+MySQL专家+体验bug修复

### DIFF
--- a/kaiwu/builtin_experts/mysql/SKILL.md
+++ b/kaiwu/builtin_experts/mysql/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: MySQLExpert
+version: 1.0.0
+trigger_keywords: [mysql, 数据库, 建表, 索引, 查询, 连接池, pymysql, 存储过程, 分库分表]
+trigger_min_confidence: 0.7
+pipeline: [locator, generator, verifier]
+lifecycle: mature
+---
+
+## 领域知识
+
+- 建表规范：InnoDB引擎，utf8mb4字符集，主键BIGINT AUTO_INCREMENT，字段加NOT NULL和DEFAULT
+- 索引设计：WHERE/JOIN/ORDER BY列建索引，联合索引遵循最左前缀原则，区分度高的列放前面
+- 覆盖索引：SELECT列都在索引中避免回表（Extra显示Using index）
+- 避免索引失效：不在索引列上用函数或运算、不用前导模糊LIKE、注意隐式类型转换
+- SQL注入防护：Python用参数化查询（%s占位符），绝不拼接用户输入的SQL字符串
+- 连接池：SQLAlchemy用QueuePool（pool_size=5, max_overflow=10），pymysql加connect_timeout和read_timeout
+- 事务：写操作加try/except/rollback/finally(close)，只读查询不开启事务
+- 慢查询：EXPLAIN分析执行计划，type列至少range级别，避免ALL全表扫描
+- 分页优化：深分页用游标方式WHERE id > last_id LIMIT n代替LIMIT+OFFSET
+- 批量操作：INSERT批量VALUES每批500-1000条，UPDATE用CASE WHEN
+- 表设计：字段类型最小化满足需求（用INT不用BIGINT，用VARCHAR不用TEXT），避免NULL列
+- 读写分离：写走主库，读走从库，SQLAlchemy用binds路由
+- 迁移工具：Alembic管理schema版本，UP/DOWN都要实现，autogenerate后手动检查
+- Python连接：优先用SQLAlchemy ORM做CRUD，复杂查询用原生SQL（text()），不混用裸cursor和ORM
+- 监控：开启slow_query_log，long_query_time设为1秒，定期检查没走索引的查询
+
+## 经验规则（自动生成）

--- a/kaiwu/cli/onboarding.py
+++ b/kaiwu/cli/onboarding.py
@@ -108,7 +108,7 @@ def _configure_api(net: dict) -> dict:
         api_key = Prompt.ask(
             "  API Key [dim](本地模型留空，直接回车)[/dim]",
             default="",
-            password=True,
+            password=False,
         ).strip()
 
         model = Prompt.ask(

--- a/kaiwu/cli/repl.py
+++ b/kaiwu/cli/repl.py
@@ -33,6 +33,7 @@ REPL_COMMANDS = {
     "/stats":   "查看任务统计和Gate准确率",
     "/exit":    "退出",
 }
+REPL_TIPS = "多行粘贴: 直接粘贴代码，按 Esc+Enter 提交  |  单行输入: 直接 Enter 提交"
 
 
 class SessionState:
@@ -157,6 +158,7 @@ def repl(model_path, ollama_url, ollama_model, project_root, verbose, no_search=
         status.refresh_ram()
         width = console.width
         bar = escape_html(status.render(width))
+        bar += " | Esc+Enter 提交 | /help 帮助"
         return HTML(f'<style bg="#1a1a1a" fg="#666666">{bar}</style>')
 
     # Slash command completer — 输入/后弹出命令菜单
@@ -182,6 +184,7 @@ def repl(model_path, ollama_url, ollama_model, project_root, verbose, no_search=
             user_input = session.prompt(
                 " > ",
                 bottom_toolbar=_toolbar,
+                multiline=True,
             ).strip()
         except (KeyboardInterrupt, EOFError):
             console.print("\n  [dim]bye[/dim]")
@@ -201,6 +204,8 @@ def repl(model_path, ollama_url, ollama_model, project_root, verbose, no_search=
                 break
 
             elif cmd == "/help":
+                console.print(f"  [dim]{REPL_TIPS}[/dim]")
+                console.print()
                 for k, v in REPL_COMMANDS.items():
                     console.print(f"  [cyan]{k:10s}[/cyan] {v}")
 

--- a/kaiwu/core/model_capability.py
+++ b/kaiwu/core/model_capability.py
@@ -84,6 +84,7 @@ def detect_model_tier(model_name: str, ollama_url: str = "http://localhost:11434
     if tier is None:
         tier = _detect_from_name(model_name)
 
+    tier = _validate_hardware(model_name, tier)
     _tier_cache[model_name] = tier
     logger.info("[model_capability] %s → %s", model_name, tier.value)
     return tier
@@ -268,3 +269,51 @@ def tier_display_name(tier: ModelTier) -> str:
         ModelTier.MEDIUM: "中等模型",
         ModelTier.LARGE: "大模型模式",
     }[tier]
+
+
+def _detect_vram_gb() -> float | None:     #用nvidia-smi检测gpu显存，不是英伟达的卡返回none
+    try:
+        import subprocess
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=memory.total",
+             "--format=csv,noheader,nounits"],
+            timeout=5, text=True,
+        )
+        vram_mib = float(out.strip().splitlines()[0])
+        return round(vram_mib / 1024, 1)
+    except Exception:
+        return None
+
+
+def _detect_sysram_gb() -> float | None:
+    try:
+        import psutil  #检测总机内存，psutil已经是项目依赖
+        return round(psutil.virtual_memory().total / (1024 ** 3), 1)
+    except Exception:
+        return None
+
+#硬件能力与模型参数交叉验证，如果跑不动就做告知（logging.warning），暂时不改tier 跳过不影响主流程
+def _validate_hardware(model_name: str, tier: ModelTier) -> ModelTier:
+    vram = _detect_vram_gb()
+    sysram = _detect_sysram_gb()
+    if vram is None:
+        return tier
+    total_ram = vram + (sysram or 0)
+#根据总内存去决定级别，如果显存溢出ollama自己默认在cpu占用系统内存跑，后续要做优化比如增加内存分配的功能，毕竟显卡才是跑llm的核心
+    if total_ram < 8:
+        hw_limit = ModelTier.SMALL
+    elif total_ram < 16:
+        hw_limit = ModelTier.SMALL
+    elif total_ram < 24:
+        hw_limit = ModelTier.MEDIUM
+    else:
+        hw_limit = ModelTier.LARGE
+    _order = {ModelTier.SMALL: 0, ModelTier.MEDIUM: 1, ModelTier.LARGE: 2}
+    if _order[tier] > _order[hw_limit]:
+        logger.warning(
+            "[model_capability]    硬件可能无法流畅运行 %s(VRAM %.1fGB + RAM %.1fGB = %.1fGB)"
+            "建议换用较小的模型。",
+            model_name, vram, sysram or 0, total_ram,
+        )
+
+    return tier

--- a/kaiwu/experts/generator.py
+++ b/kaiwu/experts/generator.py
@@ -164,6 +164,7 @@ GENERATOR_TEST_PROMPT = """你是测试生成专家。为下面的代码生成 p
 
 
 _LANG_KEYWORDS = {
+    ".py":   ["python", "代码", "程序", "sqlalchemy", "pymysql", "django", "flask", "fastapi", "sqlmodel", "mysqlclient", "aiomysql", "异步", "协程", "装饰器", "pytest", "unittest"],
     ".html": ["html", "网页", "页面", "web page", "webpage", "website", "前端页面"],
     ".js":   ["javascript", "js", "node", "nodejs", "react", "vue"],
     ".ts":   ["typescript", "ts", "angular"],

--- a/kaiwu/tests/test_p2_features.py
+++ b/kaiwu/tests/test_p2_features.py
@@ -70,6 +70,38 @@ class TestModelCapability:
         detect_model_tier("test-cache:8b", "http://localhost:99999")
         assert "test-cache:8b" in _tier_cache
 
+    def test_hardware_validate_no_warning_when_sufficient(self):#内存够
+        from unittest.mock import patch
+
+        from kaiwu.core.model_capability import ModelTier, _validate_hardware
+
+        with patch("kaiwu.core.model_capability._detect_vram_gb", return_value=24.0), \
+             patch("kaiwu.core.model_capability._detect_sysram_gb", return_value=32.0):
+            result = _validate_hardware("qwen3:72b", ModelTier.LARGE)
+            assert result == ModelTier.LARGE
+
+    def test_hardware_validate_warns_when_insufficient(self, caplog):#小跑大
+        import logging
+        from unittest.mock import patch
+
+        from kaiwu.core.model_capability import ModelTier, _validate_hardware
+        with patch("kaiwu.core.model_capability._detect_vram_gb", return_value=4.0), \
+             patch("kaiwu.core.model_capability._detect_sysram_gb", return_value=8.0):
+            with caplog.at_level(logging.WARNING):
+                result = _validate_hardware("qwen3:72b", ModelTier.LARGE)
+            assert result == ModelTier.LARGE
+            assert "硬件可能无法流畅运行" in caplog.text
+
+    def test_hardware_validate_no_nvidia_skips(self):#无英伟达卡
+        from unittest.mock import patch
+
+        from kaiwu.core.model_capability import ModelTier, _validate_hardware
+
+        with patch("kaiwu.core.model_capability._detect_vram_gb", return_value=None), \
+             patch("kaiwu.core.model_capability._detect_sysram_gb", return_value=16.0):
+            result = _validate_hardware("qwen3:72b", ModelTier.LARGE)
+            assert result == ModelTier.LARGE
+
 
 # ── Task 2: Flywheel Notifier ─────────────────────────────
 


### PR DESCRIPTION
## 改动内容
detect_model_tier() 新增 GPU 显存（nvidia-smi）和系统内存（psutil）交叉验证。
当模型参数量超出硬件能力时发出 logging.warning 告知用户，不修改 tier 返回值，保持向后兼容。

5月28日额外新增MySQL专家

5月28日，输入apikey是密码模式不能粘贴（apikey那么长不能一个一个手动输入，有输错的可能，还那么麻烦，在codex里面apikey输入也是明文保存本地）

## 改动类型
- [x] Bug 修复（模型能力检测只看名称、不看硬件，低配机器选了过大模型会导致 OOM）
- [x] 新增专家 / SKILL.md
- [ ] 性能优化
- [ ] 文档 / CI 改进
- [ ] 其他（请说明）

## 测试
- [x] 现有测试全部通过（495 passed, 1 个 Windows 平台已有的 sleep 兼容性问题）
- [x] 新增了对应测试（3 个：硬件充足不警告 / 硬件不足触发 warning / 无 NVIDIA 显卡静默跳过）
- [ ] 只改文档，无需测试

## 新增依赖（如有）
无。subprocess 是标准库，psutil 已是项目现有依赖。

## 验证方式
python -m pytest kaiwu/tests/test_p2_features.py::TestModelCapability -v
# 13 passed，包含新增的 3 个 hardware 测试


---

### MySQL 内置专家

**文件：** `kaiwu/builtin_experts/mysql/SKILL.md`

**触发关键词：** mysql, 数据库, 建表, 索引, 查询, 连接池, pymysql, 存储过程, 分库分表

**涵盖 15 条领域知识：**

| 分类 | 内容 |
|------|------|
| 建表规范 | InnoDB引擎、utf8mb4字符集、BIGINT主键、NOT NULL + DEFAULT |
| 索引设计 | 联合索引最左前缀、覆盖索引避免回表、避免函数/前导LIKE导致失效 |
| SQL安全 | Python参数化查询防注入，绝不拼接SQL |
| 连接池 | SQLAlchemy QueuePool配置（pool_size=5, max_overflow=10） |
| 事务 | try/except/rollback/finally(close)模式 |
| 性能 | EXPLAIN分析、分页游标替代OFFSET、批量CASE WHEN |
| 运维 | Alembic迁移、读写分离binds路由、slow_query_log监控 |

**测试方式：** 专家自动注册，启动后输入含"mysql 建表"等关键词的任务即可触发